### PR TITLE
Set the profile from options if present

### DIFF
--- a/bin/aws-rails-provisioner
+++ b/bin/aws-rails-provisioner
@@ -125,7 +125,7 @@ elsif options[:deploy]
     service_name: options[:service_name]
   }
   if options[:profile]
-    deploy_params[:profile] = profile
+    deploy_params[:profile] = options[:profile]
   end
   deploy_params.merge!(options[:deploy])
   deployer = Aws::RailsProvisioner::CDKDeployer.new(deploy_params)


### PR DESCRIPTION
This bug is preventing the profile option from working with `aws-rails-provisioner deploy`

*Issue #, if available:*
Currently, if the profile option is passed in through the CLI during a deploy command, the script crashes.

*Description of changes:*
We actually want to set the profile value from options if it's passed in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
